### PR TITLE
Update IGraphicsMac.mm

### DIFF
--- a/IGraphics/Platforms/IGraphicsMac.mm
+++ b/IGraphics/Platforms/IGraphicsMac.mm
@@ -449,8 +449,10 @@ void IGraphicsMac::PromptForFile(WDL_String& fileName, WDL_String& path, EFileAc
   NSString* pDefaultPath = nil;
   NSArray* pFileTypes = nil;
 
-  if (fileName.GetLength())
+  if (fileName.GetLength()){
     pDefaultFileName = [NSString stringWithUTF8String:fileName.Get()];
+    pDefaultFileName= [pDefaultFileName lastPathComponent];
+   }
   else
     pDefaultFileName = @"";
   


### PR DESCRIPTION
When using:
GetUI()->PromptForFile(filePath, path, EFileAction::Save)
the tab "Save As:" displayed full path + name of the last saved file.
Now it displays last name only, without unnecessary full path.