### PR TITLE
Reset selection function on menu clear

### DIFF
--- a/IGraphics/IGraphicsPopupMenu.h
+++ b/IGraphics/IGraphicsPopupMenu.h
@@ -291,6 +291,11 @@ public:
       SetChosenItemIdx(-1);
       SetPrefix(0);
       mCanMultiCheck = false;
+      // Drop any selection function too: IGraphics reuses one shared menu for
+      // PromptUserInput and context menus, and platform code executes the
+      // function whenever one is set -- a function surviving Clear() would
+      // fire again from a later, unrelated menu.
+      SetFunction(nullptr);
     }
     
     mMenuItems.Empty(true);


### PR DESCRIPTION
 IGraphics/IGraphicsPopupMenu.h, IPopupMenu::Clear(bool resetEverything = true) (around line 287) resets chosen-item index, prefix, and multicheck but never resets mPopupFunc. IGraphics reuses one shared IPopupMenu (mPromptPopupMenu in IGraphics.h) for both PromptUserInput dropdowns and PopupHostContextMenuForParam context menus, and platform code (e.g. IGraphicsMac.mm CreatePlatformPopupMenu, ~line 602) executes the menu's function whenever one is set. So a function set on the shared menu by one control's CreateContextMenu survives Clear() and fires again when an unrelated ICaptionControl dropdown is used — this caused a real cross-control bug . Fix: when resetEverything is true, reset mPopupFunc to nullptr in Clear(). Audit IGraphics controls and examples for any code that calls Clear() on a menu and relies on a previously set function surviving (search for SetFunction and Clear usage in IGraphics/ and Examples/) before changing behavior. Consider whether this should go upstream to iPlug2 (https://github.com/iPlug2/iPlug2).
 
 // Drop any selection function too: IGraphics reuses one shared menu for
 // PromptUserInput and context menus, and platform code executes the
// function whenever one is set -- a function surviving Clear() would
// fire again from a later, unrelated menu.
      SetFunction(nullptr);
